### PR TITLE
cmdline: digest and ignore "gui" option

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -34,6 +34,10 @@ pub struct Args {
     /// Level for message logs.
     #[arg(long = "log-level")]
     pub log_level: Option<LogLevel>,
+
+    /// GUI option for compatibility with vfkit (ignored).
+    #[arg(long, default_value_t = false)]
+    pub gui: bool,
 }
 
 /// Parse a string into a vector of substrings, all of which are separated by commas.


### PR DESCRIPTION
For compatiblity with vfkit when podman-machine executed with "--log-level debug", we need to digest and ignore "--gui" en the command line.